### PR TITLE
Bls-zexe compatible deserialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 go/cmd/example/example
 Cargo.lock
 target
+testproj

--- a/bls/src/bls/keys.rs
+++ b/bls/src/bls/keys.rs
@@ -34,7 +34,7 @@ impl PublicKey {
 
     #[inline(always)]
     pub fn serialize(&self) -> [u8; 192] {
-        G2Affine::from(&self.pk).to_uncompressed()
+        G2Affine::from(&self.pk).to_uncompressed_littleendian()
     }
 }
 impl Eq for PublicKey {}
@@ -57,7 +57,7 @@ impl Signature {
 
     #[inline(always)]
     pub fn serialize(&self) -> [u8; 96] {
-        G1Affine::from(self.sig).to_uncompressed()
+        G1Affine::from(self.sig).to_uncompressed_littleendian()
     }
 }
 impl Eq for Signature {} impl PartialEq for Signature {

--- a/bls/src/bls/keys.rs
+++ b/bls/src/bls/keys.rs
@@ -17,7 +17,7 @@ impl PrivateKey {
 
     #[inline(always)]
     pub fn sign_hash(&self, hash: &[u8; 96]) -> Result<Signature, ErrorCode> {
-       let hash_elem = G1Affine::from_uncompressed_unchecked(hash).unwrap(); 
+       let hash_elem = G1Affine::from_uncompressed_unchecked_vartime(hash).unwrap(); 
        Ok(Signature::from_sig(&hash_elem.mul(&self.sk)))
     }
 }

--- a/bls12_377/Makefile
+++ b/bls12_377/Makefile
@@ -3,10 +3,10 @@
 
 libfpc.a: src/fpc.cpp
 	rm -f libfpc.a fpc.o
-#`	gcc -march=armv7-m -mcpu=cortex-m3 -mthumb -O2 \
+	gcc -march=armv7-m -mcpu=cortex-m3 -mthumb -O2 \
 	 -funroll-all-loops \
 	 -c src/fpc.cpp
-	gcc -march=native -O2 \
+#	gcc -march=native -O2 \
 		-funroll-all-loops \
 		-c src/fpc.cpp
 	ar -rsc libfpc.a fpc.o

--- a/bls12_377/Makefile
+++ b/bls12_377/Makefile
@@ -3,10 +3,10 @@
 
 libfpc.a: src/fpc.cpp
 	rm -f libfpc.a fpc.o
-#	gcc -march=armv7-m -mcpu=cortex-m3 -mthumb -O2 \
+	gcc -march=armv7-m -mcpu=cortex-m3 -mthumb -O2 \
 	 -funroll-all-loops \
 	 -c src/fpc.cpp
-	gcc -march=native -O2 \
+#	gcc -march=native -O2 \
 		-funroll-all-loops \
 		-c src/fpc.cpp
 	ar -rsc libfpc.a fpc.o

--- a/bls12_377/Makefile
+++ b/bls12_377/Makefile
@@ -3,10 +3,10 @@
 
 libfpc.a: src/fpc.cpp
 	rm -f libfpc.a fpc.o
-	gcc -march=armv7-m -mcpu=cortex-m3 -mthumb -O2 \
+#	gcc -march=armv7-m -mcpu=cortex-m3 -mthumb -O2 \
 	 -funroll-all-loops \
 	 -c src/fpc.cpp
-#	gcc -march=native -O2 \
+	gcc -march=native -O2 \
 		-funroll-all-loops \
 		-c src/fpc.cpp
 	ar -rsc libfpc.a fpc.o

--- a/bls12_377/src/fp.rs
+++ b/bls12_377/src/fp.rs
@@ -322,6 +322,26 @@ impl Fp {
         res
     }
 
+    /// Converts an element of `Fp` into a byte representation in
+    /// little-endian byte order.
+    pub fn to_bytes_littleendian(&self) -> [u8; 48] {
+        // Turn into canonical form by computing
+        // (a.R) / R = a
+        let tmp = Fp::montgomery_reduce(
+            self.0[0], self.0[1], self.0[2], self.0[3], self.0[4], self.0[5], 0, 0, 0, 0, 0, 0,
+        );
+
+        let mut res = [0; 48];
+        LittleEndian::write_u64(&mut res[0..8], tmp.0[0]);
+        LittleEndian::write_u64(&mut res[8..16], tmp.0[1]);
+        LittleEndian::write_u64(&mut res[16..24], tmp.0[2]);
+        LittleEndian::write_u64(&mut res[24..32], tmp.0[3]);
+        LittleEndian::write_u64(&mut res[32..40], tmp.0[4]);
+        LittleEndian::write_u64(&mut res[40..48], tmp.0[5]);
+
+        res
+    }
+
     /// Returns whether or not this element is strictly lexicographically
     /// larger than its negation.
     pub fn lexicographically_largest(&self) -> Choice {

--- a/bls12_377/src/fp.rs
+++ b/bls12_377/src/fp.rs
@@ -232,6 +232,7 @@ impl Fp {
 
     /// Attempts to convert a little-endian byte representation of
     /// a scalar into an `Fp`, failing if the input is not canonical.
+    #[inline(always)]
     pub fn from_bytes(bytes: &[u8; 48]) -> CtOption<Fp> {
         let mut tmp = Fp([0, 0, 0, 0, 0, 0]);
         let modulus = modulus();
@@ -261,6 +262,45 @@ impl Fp {
         tmp *= &r_squared();
 
         CtOption::new(tmp, Choice::from(is_some))
+    }
+
+    /// Attempts to convert a little-endian byte representation of
+    /// a scalar into an `Fp`, failing if the input is not canonical.
+    /// This is a memory-optimized version of `from_bytes()`, and
+    /// is not constant-time. 
+    #[inline(always)]
+    pub fn from_bytes_vartime(bytes: &[u8; 48]) -> Option<Fp> {
+        let mut tmp = Fp([0, 0, 0, 0, 0, 0]);
+        let modulus = modulus();
+
+        tmp.0[5] = BigEndian::read_u64(&bytes[0..8]);
+        tmp.0[4] = BigEndian::read_u64(&bytes[8..16]);
+        tmp.0[3] = BigEndian::read_u64(&bytes[16..24]);
+        tmp.0[2] = BigEndian::read_u64(&bytes[24..32]);
+        tmp.0[1] = BigEndian::read_u64(&bytes[32..40]);
+        tmp.0[0] = BigEndian::read_u64(&bytes[40..48]);
+
+        // Try to subtract the modulus
+        let (_, borrow) = sbb(tmp.0[0], modulus[0], 0);
+        let (_, borrow) = sbb(tmp.0[1], modulus[1], borrow);
+        let (_, borrow) = sbb(tmp.0[2], modulus[2], borrow);
+        let (_, borrow) = sbb(tmp.0[3], modulus[3], borrow);
+        let (_, borrow) = sbb(tmp.0[4], modulus[4], borrow);
+        let (_, borrow) = sbb(tmp.0[5], modulus[5], borrow);
+
+        // If the element is smaller than MODULUS then the
+        // subtraction will underflow, producing a borrow value
+        // of 0xffff...ffff. Otherwise, it'll be zero.
+        let is_some = (borrow as u8) & 1;
+
+        // Convert to Montgomery form by computing
+        // (a.R^0 * R^2) / R = a.R
+        tmp *= &r_squared();
+
+        if is_some != 0 {
+            return None;
+        }
+        Some(tmp)
     }
 
     /// Converts an element of `Fp` into a byte representation in

--- a/bls12_377/src/g1.rs
+++ b/bls12_377/src/g1.rs
@@ -316,7 +316,7 @@ impl G1Affine {
             // Mask away the flag bits
             tmp[0] &= 0b0001_1111;
 
-            Fp::from_bytes_vartime(&tmp)
+            Fp::from_bytes_little_endian_vartime(&tmp)
         }?;
 
         // Attempt to obtain the y-coordinate
@@ -324,17 +324,17 @@ impl G1Affine {
             let mut tmp = [0; 48];
             tmp.copy_from_slice(&bytes[48..96]);
 
-            Fp::from_bytes_vartime(&tmp)
+            Fp::from_bytes_little_endian_vartime(&tmp)
         }?;
 
         // Create a point representing this value
         let p = match bool::from(infinity_flag_set) {
-            false => G1Affine {
+            true => G1Affine {
                 x,
                 y,
                 infinity: infinity_flag_set,
             }, 
-            _ => G1Affine::identity(),
+            _ => G1Affine::generator(),
         };
 
         let is_some =                    

--- a/bls12_377/src/g2.rs
+++ b/bls12_377/src/g2.rs
@@ -254,7 +254,8 @@ impl G2Affine {
         res
     }
 
-    /// Serializes this element into uncompressed form.
+    /// Serializes this element into uncompressed form in
+    /// big-endian representation.
     #[inline(always)]     
     pub fn to_uncompressed(&self) -> [u8; 192] {
         let mut res = [0; 192];
@@ -269,6 +270,24 @@ impl G2Affine {
 
         // Is this point at infinity? If so, set the second-most significant bit.
         res[0] |= u8::conditional_select(&0u8, &(1u8 << 6), self.infinity);
+
+        res
+    }
+
+    /// Serializes this element into uncompressed form in
+    /// little-endian representation. Assumes the received point
+    /// is not infinity.
+    #[inline(always)]     
+    pub fn to_uncompressed_littleendian(&self) -> [u8; 192] {
+        let mut res = [0; 192];
+
+        let x = Fp2::conditional_select(&self.x, &Fp2::zero(), self.infinity);
+        let y = Fp2::conditional_select(&self.y, &Fp2::zero(), self.infinity);
+
+        res[0..48].copy_from_slice(&x.c0.to_bytes_littleendian()[..]);
+        res[48..96].copy_from_slice(&x.c1.to_bytes_littleendian()[..]);
+        res[96..144].copy_from_slice(&y.c0.to_bytes_littleendian()[..]);
+        res[144..192].copy_from_slice(&y.c1.to_bytes_littleendian()[..]);
 
         res
     }


### PR DESCRIPTION
Adds new memory-efficient, little endian, variable time deserialization functions for processing signatures/public keys from bls-zexe

Tested by confirming hardware wallet integration works for the validator nano X app using the bls-embedded library